### PR TITLE
travis: re-enable building master

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 sudo: false
 language: generic
 
+#TODO: this is here basically because of a hack. Github assumes that, if the commits fast-forward okay, they must be okay, but that can obviously go wrong if there have been changes to master and the commits have not been rebased on top of HEAD. It'd be lovely to have a cast-iron pre-commit check; maybe bors-ng? Doesn't solve the problem of the big, green, do-the-wrong-thing attractive nuisance button.
 branches:
   only:
     - master

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,10 @@
 sudo: false
 language: generic
 
+branches:
+  only:
+    - master
+
 #TODO: hlint, cabal check, building a sdist then testing the sdist, checking the sdist isn't missing files, packunused, maybe packdeps?
 matrix:
   fast_finish: true


### PR DESCRIPTION
There's no good way of ensuring that the commits have been tested on
top of master otherwise (as opposed to merely on top of an ancestor of
master and then hoping the fast-forward works).

Ideally this would be done pre-commit, but that's rather trickier to do.