### PR TITLE
travis: use cabal-install 2.2 across the board

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,9 +14,9 @@ matrix:
     - env: CMD=stack-werror
     - env: CMD=stack-nightly
     - env: CMD=cabal-new-build GHCSERIES=8.0
-      addons: {apt: {packages: [ghc-8.0.2,cabal-install-2.0], sources: [hvr-ghc]}}
+      addons: {apt: {packages: [ghc-8.0.2,cabal-install-2.2], sources: [hvr-ghc]}}
     - env: CMD=cabal-new-build GHCSERIES=8.2
-      addons: {apt: {packages: [ghc-8.2.2,cabal-install-2.0], sources: [hvr-ghc]}}
+      addons: {apt: {packages: [ghc-8.2.2,cabal-install-2.2], sources: [hvr-ghc]}}
     - env: CMD=cabal-new-build GHCSERIES=8.4
       addons: {apt: {packages: [ghc-8.4.1,cabal-install-2.2], sources: [hvr-ghc]}}
     - env: CMD=cabal-new-build GHCSERIES=head

--- a/travis/before_install.cabal-new-build.sh
+++ b/travis/before_install.cabal-new-build.sh
@@ -4,12 +4,4 @@ set -euxo pipefail
 
 CABALOPTS=$(./travis/options.cabal-new-build.sh)
 
-#TODO: remove the condition once we can use cabal-install 2.2 and hence new-update in all configurations
-case "$GHCSERIES" in
-  head)
-    cabal new-update $CABALOPTS
-    ;;
-  *)
-    cabal update
-    ;;  
-esac
+cabal new-update $CABALOPTS


### PR DESCRIPTION
Shouldn't merge until cabal-install 2.2 has actually been released.