### PR TITLE
Fully normalise support for GHC 8.4.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,8 +24,6 @@ matrix:
   allow_failures:
     #TODO: https://github.com/fpco/stackage/issues/3365; however, we possibly don't want to be beholden to nightly's whims anyway, so maybe this should be an allowed failure.
     - env: CMD=stack-nightly
-    #TODO: allowable once cabal-install 2.2 is out
-    - env: CMD=cabal-new-build GHCSERIES=8.4
     - env: CMD=cabal-new-build GHCSERIES=head
 
 before_install:

--- a/cabal/ghc-8.4.project
+++ b/cabal/ghc-8.4.project
@@ -8,7 +8,3 @@ packages:
   ./packages/hlist
   ./packages/position
 extra-packages:
-
-allow-newer:
-  -- TODO: remove when released; https://github.com/haskell-hvr/base-noprelude/issues/8
-  base-noprelude:base


### PR DESCRIPTION
Blocked on releases of cabal-install 2.2 and base-noprelude 4.12.