### PR TITLE
Simplify *.project, per cabal issue 4797.

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -7,4 +7,3 @@ packages:
   ./packages/foldable-utils
   ./packages/hlist
   ./packages/position
-extra-packages:

--- a/cabal/ghc-8.0.project
+++ b/cabal/ghc-8.0.project
@@ -6,4 +6,3 @@ packages:
   ./packages/foldable-utils
   ./packages/hlist
   ./packages/position
-extra-packages:

--- a/cabal/ghc-8.2.project
+++ b/cabal/ghc-8.2.project
@@ -7,4 +7,3 @@ packages:
   ./packages/foldable-utils
   ./packages/hlist
   ./packages/position
-extra-packages:

--- a/cabal/ghc-8.4.project
+++ b/cabal/ghc-8.4.project
@@ -7,4 +7,3 @@ packages:
   ./packages/foldable-utils
   ./packages/hlist
   ./packages/position
-extra-packages:

--- a/cabal/ghc-head.project
+++ b/cabal/ghc-head.project
@@ -7,7 +7,6 @@ packages:
   ./packages/foldable-utils
   ./packages/hlist
   ./packages/position
-extra-packages:
 
 repository head.hackage
    url: http://head.hackage.haskell.org/


### PR DESCRIPTION
The defaults scared me, but apparently the docs are wrong!