### PR TITLE
xml: allow markupNull to be true in more cases

### DIFF
--- a/packages/xml/src/Q4C12/XML/Internal.hs
+++ b/packages/xml/src/Q4C12/XML/Internal.hs
@@ -89,7 +89,7 @@ instance (pos ~ ()) => IsString (Markup pos) where
   fromString = markupText . fromString
 
 markupNull :: Markup pos -> Bool
-markupNull (Markup tree) = maybe False null (onlyOddA tree)
+markupNull (Markup tree) = maybe False (all (LT.null . snd)) (onlyOddA tree)
 
 --TODO: shouldn't attr values be strict?
 data Element pos = Element


### PR DESCRIPTION
Ever since position information was introduced, there's been the
potential for having `[(pos_0, ""), (pos_1, "")]` and similar text
spans. These should be recognised as equivalent to no text at all.