### PR TITLE
8.6: disable d2cpack for now, as it depends on base-noprelude

### DIFF
--- a/cabal/ghc-8.6.project
+++ b/cabal/ghc-8.6.project
@@ -8,7 +8,7 @@ packages:
   ./packages/foldable-utils
   ./packages/hlist
 --  ./packages/position
-  ./packages/d2cpack
+--  ./packages/d2cpack
 
 -- TODO: remove once regularised
 repository head.hackage


### PR DESCRIPTION
bors r+