### PR TITLE
Ensure 'cabal-version' isn't parsed as a float.

### DIFF
--- a/packages/position/package.yaml
+++ b/packages/position/package.yaml
@@ -10,7 +10,7 @@ defaults:
   local: ../../hpack/defaults.rolling.yaml
 
 verbatim:
-  cabal-version: 2.0
+  cabal-version: "2.0"
 
 library:
   source-dirs:

--- a/packages/prelude/package.yaml
+++ b/packages/prelude/package.yaml
@@ -10,7 +10,7 @@ defaults:
   local: ../../hpack/defaults.rolling.yaml
 
 verbatim:
-  cabal-version: 2.0
+  cabal-version: "2.0"
 
 library:
   source-dirs:


### PR DESCRIPTION
YAML is dumb like that.

bors r+