### PR TITLE
Replace the hpack defaults submodule with a top-level default

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "hpack"]
-	path = hpack
-	url = https://github.com/quasicomputational/hpack-defaults

--- a/hpack-defaults.yaml
+++ b/hpack-defaults.yaml
@@ -1,0 +1,4 @@
+defaults:
+  github: quasicomputational/hpack-defaults
+  ref: 10c53d06ae6555a3b264a0040788051c6874505a
+  path: defaults.rolling.yaml

--- a/packages/defrost/package.yaml
+++ b/packages/defrost/package.yaml
@@ -7,7 +7,7 @@ license: BSD2
 license-file:
   - LICENSE.BSD2
 defaults:
-  local: ../../hpack/defaults.rolling.yaml
+  local: ../../hpack-defaults.yaml
 extra-doc-files:
   - "README.markdown"
 

--- a/packages/foldable-utils/package.yaml
+++ b/packages/foldable-utils/package.yaml
@@ -7,7 +7,7 @@ license: BSD2
 license-file:
   - LICENSE.BSD2
 defaults:
-  local: ../../hpack/defaults.rolling.yaml
+  local: ../../hpack-defaults.yaml
 
 custom-setup:
   dependencies:

--- a/packages/hlist/package.yaml
+++ b/packages/hlist/package.yaml
@@ -7,7 +7,7 @@ license: BSD2
 license-file:
   - LICENSE.BSD2
 defaults:
-  local: ../../hpack/defaults.rolling.yaml
+  local: ../../hpack-defaults.yaml
 
 library:
   source-dirs:

--- a/packages/mappend/package.yaml
+++ b/packages/mappend/package.yaml
@@ -7,7 +7,7 @@ license: BSD2
 license-file:
   - LICENSE.BSD2
 defaults:
-  local: ../../hpack/defaults.rolling.yaml
+  local: ../../hpack-defaults.yaml
 
 library:
   source-dirs:

--- a/packages/meta/package.yaml
+++ b/packages/meta/package.yaml
@@ -7,7 +7,7 @@ license: BSD2
 license-file:
   - LICENSE.BSD2
 defaults:
-  local: ../../hpack/defaults.rolling.yaml
+  local: ../../hpack-defaults.yaml
 
 verbatim:
   cabal-version: "2.0"

--- a/packages/position/package.yaml
+++ b/packages/position/package.yaml
@@ -7,7 +7,7 @@ license: BSD2
 license-file:
   - LICENSE.BSD2
 defaults:
-  local: ../../hpack/defaults.rolling.yaml
+  local: ../../hpack-defaults.yaml
 
 verbatim:
   cabal-version: "2.0"

--- a/packages/prelude/package.yaml
+++ b/packages/prelude/package.yaml
@@ -7,7 +7,7 @@ license: BSD2
 license-file:
   - LICENSE.BSD2
 defaults:
-  local: ../../hpack/defaults.rolling.yaml
+  local: ../../hpack-defaults.yaml
 
 verbatim:
   cabal-version: "2.0"

--- a/packages/project-file/package.yaml
+++ b/packages/project-file/package.yaml
@@ -7,7 +7,7 @@ license: BSD2
 license-file:
   - LICENSE.BSD2
 defaults:
-  local: ../../hpack/defaults.rolling.yaml
+  local: ../../hpack-defaults.yaml
 
 verbatim:
   cabal-version: "2.0"

--- a/packages/refreeze/package.yaml
+++ b/packages/refreeze/package.yaml
@@ -7,7 +7,7 @@ license: BSD2
 license-file:
   - LICENSE.BSD2
 defaults:
-  local: ../../hpack/defaults.rolling.yaml
+  local: ../../hpack-defaults.yaml
 
 verbatim:
   cabal-version: "2.0"

--- a/packages/romnum/package.yaml
+++ b/packages/romnum/package.yaml
@@ -7,7 +7,7 @@ license: BSD2
 license-file:
   - LICENSE.BSD2
 defaults:
-  local: ../../hpack/defaults.rolling.yaml
+  local: ../../hpack-defaults.yaml
 
 library:
   source-dirs:

--- a/packages/twofinger/package.yaml
+++ b/packages/twofinger/package.yaml
@@ -23,7 +23,7 @@ extra-doc-files:
   - SUPPORT.markdown
   #TODO: Should this file (i.e., package.yaml) be included in sdists? Question of what to do for the includes, in that case.
 defaults:
-  local: ../../hpack/defaults.rolling.yaml
+  local: ../../hpack-defaults.yaml
 
 #TODO: https://github.com/commercialhaskell/stack/issues/2583 means we can't get away with putting the QuickCheck stuff into another package.
 

--- a/packages/xhtml2html/package.yaml
+++ b/packages/xhtml2html/package.yaml
@@ -13,7 +13,7 @@ extra-source-files:
   - test/golden/**/*.out
   - test/golden/**/*.fails
 defaults:
-  local: ../../hpack/defaults.rolling.yaml
+  local: ../../hpack-defaults.yaml
 
 library:
   source-dirs:

--- a/packages/xml-core/package.yaml
+++ b/packages/xml-core/package.yaml
@@ -14,7 +14,7 @@ extra-source-files:
   - test/golden/**/*.errout
   - test/golden/**/*.fails
 defaults:
-  local: ../../hpack/defaults.rolling.yaml
+  local: ../../hpack-defaults.yaml
 
 verbatim:
   cabal-version: "2.0"

--- a/packages/xml-desc/package.yaml
+++ b/packages/xml-desc/package.yaml
@@ -9,7 +9,7 @@ license-file:
 extra-doc-files:
   - README.markdown
 defaults:
-  local: ../../hpack/defaults.rolling.yaml
+  local: ../../hpack-defaults.yaml
 
 verbatim:
   cabal-version: "2.0"


### PR DESCRIPTION
This gets us the same behaviour of pinning the commit once without
having to touch submodules, which is a win.

bors r+