### PR TITLE
Fix dangling reference to gen-travis in top-level README.

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -30,4 +30,4 @@ In roughly decreasing order of likelihood of being useful to anyone else, they a
 
   It's not very comprehensive: I'm adding things as I find I need them.
 
-* [q4c12-gen-travis](packages/gen-travis) is local housekeeping. It generates the `.travis.yml` script for CI. It's working well for me so far, so maybe I should try to turn it into a generally useful thing.
+* [q4c12-meta](packages/meta) is local housekeeping. It generates the `.travis.yml` script for CI and the various GHC-version-specific `.project` files under `cabal/`, as well as `refreeze.xml`. It's working well for me so far, so maybe I should try to turn it into a generally useful thing.


### PR DESCRIPTION
bors r+