### PR TITLE
defrost: allow specification of the versioning policy per dep

### DIFF
--- a/packages/prelude/README.markdown
+++ b/packages/prelude/README.markdown
@@ -1,0 +1,4 @@
+Versioning policy
+=================
+
+This package follows semantic versioning. In practice, as it's designed to be used unqualified and without an explicit enumeration of imports, you should treat it as if it followed the PVP: fix the first two components of the version number.

--- a/packages/prelude/package.yaml
+++ b/packages/prelude/package.yaml
@@ -6,6 +6,8 @@ author: quasicomputational <quasicomputational@gmail.com>
 license: BSD2
 license-file:
   - LICENSE.BSD2
+extra-doc-files:
+  - README.markdown
 defaults:
   local: ../../hpack-defaults.yaml
 


### PR DESCRIPTION
This means that appropriate bounds can be placed on dependencies
following the PVP or semantic versioning, as well as taking into
account whether imports are open or closed.

bors r+