### PR TITLE
travis: add with-hc-pkg to the per-GHC projects

### DIFF
--- a/cabal/ghc-8.2.project
+++ b/cabal/ghc-8.2.project
@@ -11,6 +11,7 @@ packages:
   packages/xml-core
   packages/xml-desc
 with-compiler: ghc-8.2.2
+with-hc-pkg: ghc-pkg-8.2.2
 optimization: False
 benchmarks: true
 tests: true

--- a/cabal/ghc-8.4.project
+++ b/cabal/ghc-8.4.project
@@ -11,6 +11,7 @@ packages:
   packages/xml-core
   packages/xml-desc
 with-compiler: ghc-8.4.4
+with-hc-pkg: ghc-pkg-8.4.4
 optimization: False
 benchmarks: true
 tests: true

--- a/cabal/ghc-8.6.project
+++ b/cabal/ghc-8.6.project
@@ -15,6 +15,7 @@ packages:
   packages/xml-core
   packages/xml-desc
 with-compiler: ghc-8.6.3
+with-hc-pkg: ghc-pkg-8.6.3
 optimization: False
 benchmarks: true
 tests: true

--- a/cabal/ghc-head.project
+++ b/cabal/ghc-head.project
@@ -15,6 +15,7 @@ packages:
   packages/xml-core
   packages/xml-desc
 with-compiler: ghc-head
+with-hc-pkg: ghc-pkg-head
 optimization: False
 benchmarks: true
 tests: true

--- a/packages/meta/src/Q4C12/Meta.hs
+++ b/packages/meta/src/Q4C12/Meta.hs
@@ -172,6 +172,8 @@ generateProjectFiles = traverseWithKey_ $ \ buildName build -> do
     , flip fmap ( buildPackages build ) $ \ package ->
         "  " <> LT.pack ( packageDirectory package )
     , [ "with-compiler: ghc-" <> LT.fromStrict ( ghcVersion ( buildGHCVersion build ) )
+      -- Needed or else Cabal's autodetection of the ghc-pkg command goes wrong. See haskell/cabal#5792.
+      , "with-hc-pkg: ghc-pkg-" <> LT.fromStrict ( ghcVersion ( buildGHCVersion build ) )
       , "optimization: False"
       , "benchmarks: true"
       , "tests: true"


### PR DESCRIPTION
Otherwise, Cabal can fail to find the correct ghc-pkg binary.

bors r+