### PR TITLE
travis: use find | xargs, not -exec

### DIFF
--- a/travis/meta.sh
+++ b/travis/meta.sh
@@ -14,8 +14,9 @@ curl -L https://github.com/sol/hpack/releases/download/"$HPACKVER"/hpack_linux.g
 
 chmod +x "$HOME"/.local/bin/hpack
 
-# Run hpack on packages, and see if we're left with a clean working tree.
-# TODO: when https://github.com/sol/hpack/pull/346 is merged/released, we can do that instead of asking git!
-find packages/ -type f -path 'packages/*/package.yaml' -exec "$HOME"/.local/bin/hpack \{\} \;
+# Run hpack on packages, and see if we're left with a clean working tree. Note that we have to use xargs because find swallows return codes and we want to detect things that make hpack fail (e.g., hand-modification of .cabal files, bad YAML).
+# TODO: when https://github.com/sol/hpack/pull/346 is merged/released, we can do that instead of asking git! Still have to use xargs, though.
+find packages/ -type f -path 'packages/*/package.yaml' -print0 \
+  | xargs -0 -n1 hpack
 
 git diff-index --exit-code HEAD


### PR DESCRIPTION
`find -exec` swallows return codes.

bors r+