### PR TITLE
meta: run defrost to pick up unfrozen dependencies.

### DIFF
--- a/packages/defrost/src/Q4C12/Defrost.hs
+++ b/packages/defrost/src/Q4C12/Defrost.hs
@@ -2,6 +2,7 @@
 
 module Q4C12.Defrost
   ( env
+  , addConstraints
   , Env
   , defrost
   , defrostTarball
@@ -131,6 +132,10 @@ instance Aeson.ToJSON Env where
 env :: OS -> Arch -> FlagAssignment -> CompilerFlavor -> Version -> Seq Constraint -> Env
 env os arch flags compiler compilerVersion =
   Env ( SystemEnv os arch flags compiler compilerVersion )
+
+addConstraints :: Seq Constraint -> Env -> Env
+addConstraints constraints ( Env system constraints' ) =
+  Env system ( constraints <> constraints' )
 
 -- Strictly speaking, we don't need to canonicalise. However, for output nicety (and test output stability), we do.
 canonicalVersionRange :: VersionRange -> VersionRange

--- a/travis/meta.sh
+++ b/travis/meta.sh
@@ -4,6 +4,8 @@ set -euxo pipefail
 
 cabal v2-run --project-file=cabal/"$PROJECT".project meta -- check-hash
 
+cabal v2-run --project-file=cabal/"$PROJECT".project meta -- check-defrost
+
 mkdir -p "$HOME"/.local/bin
 
 HPACKVER=0.31.2


### PR DESCRIPTION
This will actually work better than the upcoming
--reject-unconstrained-dependencies flag in cabal-install, as that can
have false negatives if there are extra constraints floating around.

bors r+