### PR TITLE
meta: make exclusions from builds cascade.

### DIFF
--- a/packages/defrost/config.xml
+++ b/packages/defrost/config.xml
@@ -1,5 +1,4 @@
 <package-config>
   <exclude>
-    <build>ghc-8.4</build>
   </exclude>
 </package-config>

--- a/packages/meta/config.xml
+++ b/packages/meta/config.xml
@@ -1,5 +1,4 @@
 <package-config>
   <exclude>
-    <build>ghc-8.4</build>
   </exclude>
 </package-config>

--- a/packages/meta/package.yaml
+++ b/packages/meta/package.yaml
@@ -26,6 +26,7 @@ library:
     bytestring:
     Cabal:
     containers:
+    lens:
     monoidal-containers:
     optparse-applicative:
     process:
@@ -35,6 +36,7 @@ library:
     q4c12-xml-core:
     q4c12-xml-desc:
     text:
+    transformers:
 
 executables:
   meta:

--- a/packages/meta/q4c12-meta.cabal
+++ b/packages/meta/q4c12-meta.cabal
@@ -4,7 +4,7 @@ cabal-version: 2.2
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 36f0f2f06fcff9cb4a8b9587326c3696be29c77abdb64d7aaf20b87b2d388065
+-- hash: 0b782e79f1171c1923dc90b2b1b322027144d654e71659a5f9a57dfde6bed57e
 
 name:           q4c12-meta
 version:        0
@@ -34,6 +34,7 @@ library
     , base
     , bytestring
     , containers
+    , lens
     , monoidal-containers
     , optparse-applicative
     , process
@@ -43,6 +44,7 @@ library
     , q4c12-xml-core
     , q4c12-xml-desc
     , text
+    , transformers
   mixins:
       base hiding (Prelude)
   default-language: Haskell2010

--- a/packages/prelude/src/Prelude.hs
+++ b/packages/prelude/src/Prelude.hs
@@ -201,7 +201,7 @@ import System.Directory as Export
 
 -- lens imports for re-export
 import Control.Lens as Export
-  (Lens, Lens', set, over, view, views, (<>~), Iso, Iso', AnIso, AnIso', from, iso, withIso, Prism, Prism', APrism, APrism', preview, matching, review, withPrism, foldMapOf, anyOf, (<+=), (<+~), Traversal, Traversal', Getting)
+  (Lens, Lens', set, over, view, views, (<>~), Iso, Iso', AnIso, AnIso', from, iso, withIso, Prism, Prism', APrism, APrism', preview, matching, review, withPrism, foldMapOf, anyOf, (<+=), (<+~), Traversal, Traversal', Getting, Getter)
 import Data.Set.Lens as Export
   ( setOf
   )

--- a/packages/project-file/config.xml
+++ b/packages/project-file/config.xml
@@ -1,5 +1,4 @@
 <package-config>
   <exclude>
-    <build>ghc-8.4</build>
   </exclude>
 </package-config>


### PR DESCRIPTION
Now a blockage with a root cause in a single package doesn't need to
be cleared from multiple locations.

For debuggability, a new `explain-exclusion` command has also been
added.

bors r+