### PR TITLE
Drop dependency on transformers-compat.

### DIFF
--- a/packages/prelude/package.yaml
+++ b/packages/prelude/package.yaml
@@ -50,7 +50,6 @@ library:
       mixin:
         # Hide the leaky writer versions
         - hiding (Control.Monad.Trans.RWS, Control.Monad.Trans.Writer)
-    transformers-compat:
     writer-cps-transformers:
   when:
     condition: "!impl(ghc >= 8.6)"

--- a/packages/prelude/q4c12-prelude.cabal
+++ b/packages/prelude/q4c12-prelude.cabal
@@ -4,7 +4,7 @@ cabal-version: 2.2
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: aefe1e410d467158c7f040edd540686fa884791b932ab4c78d6e28811dd3b56a
+-- hash: 766a06901706f15d572443acf9fd59d9826d7c3099b0b694c772a7ac7e868f19
 
 name:           q4c12-prelude
 version:        0
@@ -55,7 +55,6 @@ library
     , time
     , time-compat
     , transformers
-    , transformers-compat
     , writer-cps-transformers
   mixins:
       base hiding (Prelude)

--- a/packages/xml-core/package.yaml
+++ b/packages/xml-core/package.yaml
@@ -46,7 +46,6 @@ library:
       # Hide the leaky WriterT
       mixin:
         - hiding (Control.Monad.Trans.RWS, Control.Monad.Trans.Writer)
-    transformers-compat:
     writer-cps-transformers:
 
 tests:

--- a/packages/xml-core/q4c12-xml-core.cabal
+++ b/packages/xml-core/q4c12-xml-core.cabal
@@ -4,7 +4,7 @@ cabal-version: 2.2
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: b28af74e06642a468f94ce5e102e13d9742c1ae66d206a7f98787607f7db7151
+-- hash: db515143d0a45bbf93a90eb72b49b0a9566ef91096ca3c99e850c1415d03b63a
 
 name:           q4c12-xml-core
 version:        0
@@ -212,7 +212,6 @@ library
     , text
     , text-icu
     , transformers
-    , transformers-compat
     , writer-cps-transformers
   mixins:
       base hiding (Prelude)

--- a/packages/xml-desc/package.yaml
+++ b/packages/xml-desc/package.yaml
@@ -45,7 +45,6 @@ library:
       # Hide the leaky WriterT
       mixin:
         - hiding (Control.Monad.Trans.RWS, Control.Monad.Trans.Writer)
-    transformers-compat:
     writer-cps-transformers:
 
 #TODO: tests

--- a/packages/xml-desc/q4c12-xml-desc.cabal
+++ b/packages/xml-desc/q4c12-xml-desc.cabal
@@ -4,7 +4,7 @@ cabal-version: 2.2
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 48399846e6ee6287f440d468cf63b19eb795bc9ac85dd9eda09c43aa678f0c15
+-- hash: 695013aae1bfe25c82f87ed271e7be573f3446828f3354a153f2917e19c44600
 
 name:           q4c12-xml-desc
 version:        0
@@ -50,7 +50,6 @@ library
     , text
     , text-icu
     , transformers
-    , transformers-compat
     , writer-cps-transformers
   mixins:
       base hiding (Prelude)


### PR DESCRIPTION
All of the versions of GHC we support come with recent enough
`transformers`.

bors r+